### PR TITLE
Expose the StringStream constructor

### DIFF
--- a/src/stringstream.ts
+++ b/src/stringstream.ts
@@ -23,7 +23,6 @@ export class StringStream {
   private lastColumnPos: number = 0
   private lastColumnValue: number = 0
 
-  /// @internal
   constructor(
     /// The line.
     public string: string,


### PR DESCRIPTION
`new StringStream(…)` is used externally by parsers, so the `@internal` annotation should be removed from the constructor.
