### PR TITLE
Fix parsing stuck at exactly the end of the viewport.

### DIFF
--- a/src/stream-parser.ts
+++ b/src/stream-parser.ts
@@ -195,7 +195,7 @@ class Parse<State> implements PartialParse {
     while (this.parsedPos < end) this.parseLine(context)
     if (this.chunkStart < this.parsedPos) this.finishChunk()
     if (this.parsedPos >= parseEnd) return this.finish()
-    if (context && this.parsedPos > context.viewport.to) {
+    if (context && this.parsedPos >= context.viewport.to) {
       context.skipUntilInView(this.parsedPos, parseEnd)
       return this.finish()
     }


### PR DESCRIPTION
Fixes https://discuss.codemirror.net/t/long-document-stops-parsing-halfway/3605/14