### PR TITLE
fix(parse): avoid infinite loop in advance()

### DIFF
--- a/src/stream-parser.ts
+++ b/src/stream-parser.ts
@@ -212,7 +212,7 @@ class Parse<State> implements PartialParse {
   }
 
   stopAt(pos: number) {
-    this.stoppedAt = pos
+    this.stoppedAt = Math.min(pos, this.to)
   }
 
   lineAfter(pos: number) {

--- a/src/stream-parser.ts
+++ b/src/stream-parser.ts
@@ -198,7 +198,7 @@ class Parse<State> implements PartialParse {
 
   advance() {
     let context = ParseContext.get()
-    let parseEnd = this.stoppedAt == null ? this.to : this.stoppedAt
+    let parseEnd = this.stoppedAt == null ? this.to : Math.min(this.to, this.stoppedAt)
     let end = Math.min(parseEnd, this.chunkStart + C.ChunkSize)
     if (context) end = Math.min(end, context.viewport.to)
     while (this.parsedPos < end) this.parseLine(context)
@@ -212,7 +212,7 @@ class Parse<State> implements PartialParse {
   }
 
   stopAt(pos: number) {
-    this.stoppedAt = Math.min(pos, this.to)
+    this.stoppedAt = pos
   }
 
   lineAfter(pos: number) {


### PR DESCRIPTION
When `stoppedAt` > `this.to`, it causes an infinite loop in `advance()`.
I have a case with a custom nested parser for Markdown something like:

```js
export function parseFrontmatterCode(config: {
  codeParser?: null | Parser
}): MarkdownExtension {
  let { codeParser } = config
  let wrap = parseMixed((node: TreeCursor, input: Input) => {
    let id = node.type.id
    if (codeParser && id == typeFrontmatter) {
      return {
        parser: codeParser,
        overlay: node => node.type.name == 'CodeText'
      }
    }
    return null
  })
  return { wrap }
}
```

